### PR TITLE
Add sponsor field to `package.json`

### DIFF
--- a/htmlhint/package.json
+++ b/htmlhint/package.json
@@ -9,6 +9,9 @@
     "color": "#0000FF",
     "theme": "dark"
   },
+  "sponsor": {
+    "url": "https://opencollective.com/htmlhint"
+  },
   "license": "SEE LICENSE IN LICENSE.md",
   "bugs": {
     "url": "https://github.com/htmlhint/vscode-htmlhint/issues",


### PR DESCRIPTION
This will show on the VS Code Extension marketplace once published.