### PR TITLE
v1.0.4 Release

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,16 +1,7 @@
 {
   "version": "0.2",
-  "words": [
-    "htmlhint",
-    "htmlhintrc",
-    "mylang",
-    "ruleset",
-    "tagname",
-    "VSIX"
-  ],
+  "words": ["htmlhint", "htmlhintrc", "mylang", "ruleset", "tagname", "VSIX"],
   "language": "en-US",
-  "ignorePaths": [
-    ".cspell.json"
-  ],
+  "ignorePaths": [".cspell.json"],
   "useGitignore": true
 }

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,9 +1,12 @@
-name: 'Check spelling'
+name: "Check spelling"
 on: # rebuild any PRs and main branch changes
   push:
     branches: [main]
   pull_request:
     branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   spellcheck:
@@ -13,6 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: streetsidesoftware/cspell-action@v2
         with:
+          check_dot_files: false
+          incremental_files_only: true
           inline: warning
           strict: false
-          incremental_files_only: true

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,4 +1,4 @@
-name: Super Linter
+name: "Super Linter"
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ VS Code extension to support HTMLHint, an HTML linter.
     <img alt="VS Code Marketplace Downloads" src="https://img.shields.io/visual-studio-marketplace/d/HTMLHint.vscode-htmlhint"></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=HTMLHint.vscode-htmlhint">
     <img alt="VS Code Marketplace Installs" src="https://img.shields.io/visual-studio-marketplace/i/HTMLHint.vscode-htmlhint"></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=HTMLHint.vscode-htmlhint">
+    <img alt="VS Code Marketplace Ratings" src="https://img.shields.io/visual-studio-marketplace/r/HTMLHint.vscode-htmlhint"></a>
   <a href="https://twitter.com/htmlhint">
     <img alt="Follow HTMLHint on Twitter" src="https://img.shields.io/twitter/follow/htmlhint.svg?label=follow+htmlhint&style=flat-square"></a>
 </p>

--- a/htmlhint-server/.vscode/settings.json
+++ b/htmlhint-server/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "javascript.validate.enable": false,
   "files.trimTrailingWhitespace": true,
   "editor.insertSpaces": false
 }

--- a/htmlhint-server/.vscode/tasks.json
+++ b/htmlhint-server/.vscode/tasks.json
@@ -3,7 +3,7 @@
   "command": "npm",
   "type": "shell",
   "presentation": {
-    "reveal": "silent",
+    "reveal": "silent"
   },
   "args": ["run", "watch"],
   "isBackground": true,

--- a/htmlhint-server/src/tsconfig.json
+++ b/htmlhint-server/src/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
+    "skipLibCheck": true,
     "sourceMap": true,
     "outDir": "../../htmlhint/server",
     "lib": ["es6"]

--- a/htmlhint-server/src/typings-custom/htmlhint.d.ts
+++ b/htmlhint-server/src/typings-custom/htmlhint.d.ts
@@ -1,5 +1,4 @@
-declare module 'htmlhint' {
-
+declare module "htmlhint" {
   // version >= 0.11.0 es6
   export default HTMLHint;
 
@@ -11,18 +10,18 @@ declare module 'htmlhint' {
   }
 
   export interface Error {
-    type: string,
-    message: string,
-    raw: string,
-    evidence: string,
-    line: number,
-    col: number,
-    rule: Rule
+    type: string;
+    message: string;
+    raw: string;
+    evidence: string;
+    line: number;
+    col: number;
+    rule: Rule;
   }
 
   export interface Rule {
-    id: string,
-    description: string,
-    link: string
+    id: string;
+    description: string;
+    link: string;
   }
 }

--- a/htmlhint-server/src/typings-custom/thenable.d.ts
+++ b/htmlhint-server/src/typings-custom/thenable.d.ts
@@ -1,1 +1,1 @@
-interface Thenable<T> extends PromiseLike<T> { }
+interface Thenable<T> extends PromiseLike<T> {}

--- a/htmlhint/.vscode/tasks.json
+++ b/htmlhint/.vscode/tasks.json
@@ -3,7 +3,7 @@
   "command": "npm",
   "type": "shell",
   "presentation": {
-    "reveal": "silent",
+    "reveal": "silent"
   },
   "isBackground": true,
   "problemMatcher": "$tsc-watch"

--- a/htmlhint/.vscodeignore
+++ b/htmlhint/.vscodeignore
@@ -27,5 +27,8 @@ images/status-bar.png
 **/node_modules/**/license
 **/node_modules/**/license
 **/node_modules/**/LICENSE
+**/node_modules/**/package-lock.json
+**/node_modules/**/settings.json
+**/node_modules/**/*.test.js
 tsconfig.json
 typings/**

--- a/htmlhint/CHANGELOG.md
+++ b/htmlhint/CHANGELOG.md
@@ -1,8 +1,12 @@
-# Change Log
+# Changelog
 
 All notable changes to the "vscode-htmlhint" extension will be documented in this file.
 
 <!-- Check [Keep a Changelog](https://keepachangelog.com/) for recommendations on how to structure this file. -->
+
+### v1.0.4 (2022-10-07)
+
+- Reduced file-size and minor optimizations
 
 ### v1.0.3 (2022-09-21)
 

--- a/htmlhint/README.md
+++ b/htmlhint/README.md
@@ -1,4 +1,4 @@
-# vscode-htmlhint
+# HTMLHint - VS Code Extension
 
 Integrates the [HTMLHint](https://github.com/htmlhint/HTMLHint) static analysis tool into Visual Studio Code.
 

--- a/htmlhint/extension.ts
+++ b/htmlhint/extension.ts
@@ -1,34 +1,56 @@
-import * as path from 'path';
-import { workspace, Disposable, ExtensionContext } from 'vscode';
-import { LanguageClient, LanguageClientOptions, SettingMonitor, ServerOptions, TransportKind } from 'vscode-languageclient';
+import * as path from "path";
+import { workspace, Disposable, ExtensionContext } from "vscode";
+import {
+  LanguageClient,
+  LanguageClientOptions,
+  SettingMonitor,
+  ServerOptions,
+  TransportKind,
+} from "vscode-languageclient";
 
 export function activate(context: ExtensionContext) {
-
   // We need to go one level up since an extension compile the js code into
   // the output folder.
-  let serverModulePath = path.join(__dirname, '..', 'server', 'server.js');
-  let debugOptions = { execArgv: ["--nolazy", "--inspect=6010"], cwd: process.cwd() };
+  let serverModulePath = path.join(__dirname, "..", "server", "server.js");
+  let debugOptions = {
+    execArgv: ["--nolazy", "--inspect=6010"],
+    cwd: process.cwd(),
+  };
   let serverOptions: ServerOptions = {
     run: { module: serverModulePath, transport: TransportKind.ipc },
-    debug: { module: serverModulePath, transport: TransportKind.ipc, options: debugOptions }
+    debug: {
+      module: serverModulePath,
+      transport: TransportKind.ipc,
+      options: debugOptions,
+    },
   };
 
   // Get file types to lint from user settings
-  let config = workspace.getConfiguration('htmlhint');
-  let languages: string[] = config.get('documentSelector');
-  let documentSelector = languages.map(language => ({ language, scheme: 'file' }));
+  let config = workspace.getConfiguration("htmlhint");
+  let languages: string[] = config.get("documentSelector");
+  let documentSelector = languages.map((language) => ({
+    language,
+    scheme: "file",
+  }));
 
   // Set options
   let clientOptions: LanguageClientOptions = {
     documentSelector,
-    diagnosticCollectionName: 'htmlhint',
+    diagnosticCollectionName: "htmlhint",
     synchronize: {
-      configurationSection: 'htmlhint',
-      fileEvents: workspace.createFileSystemWatcher('**/.htmlhintrc')
-    }
-  }
+      configurationSection: "htmlhint",
+      fileEvents: workspace.createFileSystemWatcher("**/.htmlhintrc"),
+    },
+  };
 
   let forceDebug = false;
-  let client = new LanguageClient('HTML-hint', serverOptions, clientOptions, forceDebug);
-  context.subscriptions.push(new SettingMonitor(client, 'htmlhint.enable').start());
+  let client = new LanguageClient(
+    "HTML-hint",
+    serverOptions,
+    clientOptions,
+    forceDebug
+  );
+  context.subscriptions.push(
+    new SettingMonitor(client, "htmlhint.enable").start()
+  );
 }

--- a/htmlhint/package.json
+++ b/htmlhint/package.json
@@ -3,7 +3,7 @@
   "displayName": "HTMLHint",
   "description": "VS Code integration for HTMLHint - A Static Code Analysis Tool for HTML",
   "icon": "images/icon.png",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "publisher": "HTMLHint",
   "galleryBanner": {
     "color": "#333333",

--- a/htmlhint/tsconfig.json
+++ b/htmlhint/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "es6",
     "outDir": "out",
     "lib": ["es6"],
+    "skipLibCheck": true,
     "sourceMap": true
   },
   "exclude": ["node_modules", "server"]

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "author": "HTMLHint",
   "scripts": {
     "lint": "eslint -c .eslintrc.js --ext .ts .",
-    "prettier": "prettier --write \"**/*.{js,json,md,yml}\"",
-    "test": "npm run lint"
+    "prettier": "prettier --write \"**/*.{js,json,md,ts,yml}\"",
+    "test": "npm run prettier && npm run lint && cd htmlhint-server && npm run compile"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.39.0",


### PR DESCRIPTION
Minor formatting fixes and improvements:
- Prettier format all TypeScript
- Suppress error-ts2304 when compiling htmlhint-server by adding `"skipLibCheck": true` to `tsconfig.json`
- Add a few file types to `.vscodeignore` for smaller file-size
- Add VS Code Marketplace Ratings badge to README