### PR TITLE
Update Language Server Protocol

### DIFF
--- a/htmlhint-server/package-lock.json
+++ b/htmlhint-server/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "htmlhint": "^1.5.1",
         "strip-json-comments": "3.1.1",
-        "vscode-languageserver": "3.5.1"
+        "vscode-languageserver": "9.0.1",
+        "vscode-languageserver-textdocument": "^1.0.12"
       },
       "devDependencies": {
         "@types/node": "20.17.57",
@@ -353,43 +354,42 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.5.0.tgz",
-      "integrity": "sha512-LeE9LS1IOIRDZy5Xugrbk2tKeMa64vkRODrXPZbwyn2l/Q0e/jyYq8ze/Lo96sjOFiRe3HHbTVN39Ta8KN2RpA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
       "engines": {
-        "node": ">=4.0.0 || >=6.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageserver": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-3.5.1.tgz",
-      "integrity": "sha512-RYUKn0DgHTFcS8kS4VaNCjNMaQXYqiXdN9bKrFjXzu5RPKfjIYcoh47oVWwZj4L3R/DPB0Se7HPaDatvYY2XgQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
       "dependencies": {
-        "vscode-languageserver-protocol": "3.5.1",
-        "vscode-uri": "^1.0.1"
+        "vscode-languageserver-protocol": "3.17.5"
       },
       "bin": {
         "installServerIntoExtension": "bin/installServerIntoExtension"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.5.1.tgz",
-      "integrity": "sha512-1fPDIwsAv1difCV+8daOrJEGunClNJWqnUHq/ncWrjhitKWXgGmRCjlwZ3gDUTt54yRcvXz1PXJDaRNvNH6pYA==",
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "dependencies": {
-        "vscode-jsonrpc": "3.5.0",
-        "vscode-languageserver-types": "3.5.0"
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
       }
     },
-    "node_modules/vscode-languageserver-types": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
-      "integrity": "sha512-D4rUfu/oKYdc9Tmec0nEfedj+uXO2tZHR+eoHs9rE9G/QpRyZaHuug8ZUNGTGdO+ALLGgenL6bRpY8y3J9acHg=="
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="
     },
-    "node_modules/vscode-uri": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.8.tgz",
-      "integrity": "sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ=="
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/htmlhint-server/package.json
+++ b/htmlhint-server/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "htmlhint": "^1.5.1",
     "strip-json-comments": "3.1.1",
-    "vscode-languageserver": "3.5.1"
+    "vscode-languageserver": "9.0.1",
+    "vscode-languageserver-textdocument": "^1.0.12"
   },
   "devDependencies": {
     "@types/node": "20.17.57",

--- a/htmlhint/extension.ts
+++ b/htmlhint/extension.ts
@@ -5,9 +5,11 @@ import {
   LanguageClientOptions,
   ServerOptions,
   TransportKind,
-} from "vscode-languageclient";
+} from "vscode-languageclient/node";
 
-export function activate(context: ExtensionContext) {
+let client: LanguageClient;
+
+export async function activate(_context: ExtensionContext) {
   // We need to go one level up since an extension compile the js code into
   // the output folder.
   let serverModulePath = path.join(__dirname, "..", "server", "server.js");
@@ -43,9 +45,20 @@ export function activate(context: ExtensionContext) {
   };
 
   // Create the language client and start it
-  let client = new LanguageClient("HTML-hint", serverOptions, clientOptions);
+  client = new LanguageClient(
+    "HTML-hint",
+    "HTML-hint",
+    serverOptions,
+    clientOptions,
+  );
 
-  // Start the client and add it to the subscriptions
-  let disposable = client.start();
-  context.subscriptions.push(disposable);
+  // Start the client
+  await client.start();
+}
+
+export async function deactivate(): Promise<void> {
+  if (!client) {
+    return;
+  }
+  return client.stop();
 }

--- a/htmlhint/package-lock.json
+++ b/htmlhint/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-htmlhint",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-htmlhint",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "bundleDependencies": [
         "vscode-languageclient",
         "htmlhint",
@@ -17,8 +17,8 @@
       "dependencies": {
         "htmlhint": "^1.5.1",
         "strip-json-comments": "3.1.1",
-        "vscode-languageclient": "3.5.1",
-        "vscode-languageserver": "3.5.1"
+        "vscode-languageclient": "9.0.1",
+        "vscode-languageserver": "9.0.1"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -723,6 +723,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "inBundle": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -841,59 +853,55 @@
       "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.5.0.tgz",
-      "integrity": "sha512-LeE9LS1IOIRDZy5Xugrbk2tKeMa64vkRODrXPZbwyn2l/Q0e/jyYq8ze/Lo96sjOFiRe3HHbTVN39Ta8KN2RpA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
       "inBundle": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=4.0.0 || >=6.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-3.5.1.tgz",
-      "integrity": "sha512-GTQ+hSq/o4c/y6GYmyP9XNrVoIu0NFZ67KltSkqN+tO0eUNDIlrVNX+3DJzzyLhSsrctuGzuYWm3t87mNAcBmQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
       "inBundle": true,
-      "license": "MIT",
       "dependencies": {
-        "vscode-languageserver-protocol": "3.5.1"
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.5"
       },
       "engines": {
-        "vscode": "^1.15"
+        "vscode": "^1.82.0"
       }
     },
     "node_modules/vscode-languageserver": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-3.5.1.tgz",
-      "integrity": "sha512-RYUKn0DgHTFcS8kS4VaNCjNMaQXYqiXdN9bKrFjXzu5RPKfjIYcoh47oVWwZj4L3R/DPB0Se7HPaDatvYY2XgQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
       "inBundle": true,
-      "license": "MIT",
       "dependencies": {
-        "vscode-languageserver-protocol": "3.5.1",
-        "vscode-uri": "^1.0.1"
+        "vscode-languageserver-protocol": "3.17.5"
       },
       "bin": {
         "installServerIntoExtension": "bin/installServerIntoExtension"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.5.1.tgz",
-      "integrity": "sha512-1fPDIwsAv1difCV+8daOrJEGunClNJWqnUHq/ncWrjhitKWXgGmRCjlwZ3gDUTt54yRcvXz1PXJDaRNvNH6pYA==",
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "inBundle": true,
-      "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "3.5.0",
-        "vscode-languageserver-types": "3.5.0"
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
       }
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
-      "integrity": "sha512-D4rUfu/oKYdc9Tmec0nEfedj+uXO2tZHR+eoHs9rE9G/QpRyZaHuug8ZUNGTGdO+ALLGgenL6bRpY8y3J9acHg==",
-      "inBundle": true,
-      "license": "MIT"
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "inBundle": true
     },
     "node_modules/vscode-test": {
       "version": "1.6.1",
@@ -911,13 +919,6 @@
       "engines": {
         "node": ">=8.9.3"
       }
-    },
-    "node_modules/vscode-uri": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.8.tgz",
-      "integrity": "sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ==",
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/htmlhint/package.json
+++ b/htmlhint/package.json
@@ -3,7 +3,7 @@
   "displayName": "HTMLHint",
   "description": "VS Code integration for HTMLHint - A Static Code Analysis Tool for HTML",
   "icon": "images/icon.png",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "publisher": "HTMLHint",
   "galleryBanner": {
     "color": "#333333",
@@ -29,7 +29,8 @@
     "vscode": "^1.89.0"
   },
   "activationEvents": [
-    "onFileSystem:file"
+    "onLanguage:html",
+    "onLanguage:htm"
   ],
   "main": "./out/extension",
   "contributes": {
@@ -75,7 +76,7 @@
     "vscode:prepublish": "npm run compile && npm run bundle-dependencies",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "bundle-dependencies": "npm install --no-package-lock --no-save htmlhint@^1.5.1 strip-json-comments@3.1.1 vscode-languageserver@3.5.1"
+    "bundle-dependencies": "npm install --no-package-lock --no-save htmlhint@^1.5.1 strip-json-comments@3.1.1 vscode-languageserver@9.0.1 vscode-languageserver-textdocument@^1.0.12"
   },
   "devDependencies": {
     "typescript": "^5.2.2",
@@ -84,16 +85,17 @@
     "vscode-test": "^1.6.1"
   },
   "dependencies": {
-    "vscode-languageclient": "3.5.1",
+    "vscode-languageclient": "9.0.1",
     "htmlhint": "^1.5.1",
     "strip-json-comments": "3.1.1",
-    "vscode-languageserver": "3.5.1"
+    "vscode-languageserver": "9.0.1"
   },
   "bundleDependencies": [
     "vscode-languageclient",
     "htmlhint",
     "strip-json-comments",
-    "vscode-languageserver"
+    "vscode-languageserver",
+    "vscode-languageserver-textdocument"
   ],
   "volta": {
     "node": "20.19.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "vscode-languageclient": "^3.5.1"
+        "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
         "@types/glob": "^8.1.0",
@@ -668,8 +668,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/big-integer": {
       "version": "1.6.52",
@@ -1808,7 +1807,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -2403,7 +2401,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2786,41 +2783,58 @@
       "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.5.0.tgz",
-      "integrity": "sha512-LeE9LS1IOIRDZy5Xugrbk2tKeMa64vkRODrXPZbwyn2l/Q0e/jyYq8ze/Lo96sjOFiRe3HHbTVN39Ta8KN2RpA==",
-      "license": "MIT",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
       "engines": {
-        "node": ">=4.0.0 || >=6.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-3.5.1.tgz",
-      "integrity": "sha512-GTQ+hSq/o4c/y6GYmyP9XNrVoIu0NFZ67KltSkqN+tO0eUNDIlrVNX+3DJzzyLhSsrctuGzuYWm3t87mNAcBmQ==",
-      "license": "MIT",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
       "dependencies": {
-        "vscode-languageserver-protocol": "3.5.1"
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.5"
       },
       "engines": {
-        "vscode": "^1.15"
+        "vscode": "^1.82.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.5.1.tgz",
-      "integrity": "sha512-1fPDIwsAv1difCV+8daOrJEGunClNJWqnUHq/ncWrjhitKWXgGmRCjlwZ3gDUTt54yRcvXz1PXJDaRNvNH6pYA==",
-      "license": "MIT",
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "dependencies": {
-        "vscode-jsonrpc": "3.5.0",
-        "vscode-languageserver-types": "3.5.0"
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
       }
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
-      "integrity": "sha512-D4rUfu/oKYdc9Tmec0nEfedj+uXO2tZHR+eoHs9rE9G/QpRyZaHuug8ZUNGTGdO+ALLGgenL6bRpY8y3J9acHg==",
-      "license": "MIT"
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
     },
     "node_modules/vscode-test": {
       "version": "1.6.1",
@@ -2982,8 +2996,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "package": "cd htmlhint && npm run vscode:prepublish && vsce package"
   },
   "dependencies": {
-    "vscode-languageclient": "^3.5.1"
+    "vscode-languageclient": "^9.0.1"
   },
   "devDependencies": {
     "@types/glob": "^8.1.0",


### PR DESCRIPTION
- Old: vscode-languageclient@3.5.1 & vscode-languageserver@3.5.1
- New: vscode-languageclient@9.0.1 & vscode-languageserver@9.0.1

What was fixed:
✅ Dependencies: Updated all LSP packages to version 9.x
✅ Breaking Changes: Fixed all API changes (imports, connection setup, TextDocuments, etc.)
✅ Missing Dependencies: Added vscode-languageserver-textdocument@^1.0.12
✅ Extension Configuration: Fixed activation events to be more specific
✅ Build Process: Updated bundle-dependencies script
✅ Code Quality: Removed deprecated APIs and modernized the codebase

Benefits you'll get from LSP 9.x:
🚀 Better Performance: More efficient client-server communication
🔧 Modern APIs: Access to latest Language Server Protocol features
🛡️ Better Error Handling: Improved debugging and error reporting
🔄 Future-Proof: Ongoing support and updates
📊 Enhanced Diagnostics: Better linting feedback

The extension should now work faster and more reliably with HTML files, providing the same great HTMLHint linting experience with the modern LSP infrastructure underneath