### PR TITLE
feat: Add auto-fix

### DIFF
--- a/htmlhint/README.md
+++ b/htmlhint/README.md
@@ -6,7 +6,7 @@ Integrates the [HTMLHint](https://github.com/htmlhint/HTMLHint) static analysis 
 
 ## Configuration
 
-The HTMLHint extension will attempt to use the locally installed HTMLHint module (the project-specific module if present, or a globally installed HTMLHint module). If a locally installed HTMLHint isn't available, the extension will use the embedded version (current version 1.4.0).
+The HTMLHint extension will attempt to use the locally installed HTMLHint module (the project-specific module if present, or a globally installed HTMLHint module). If a locally installed HTMLHint isn't available, the extension will use the embedded version (current version 1.5.1).
 
 To install a version to the local project folder, run `npm install --save-dev htmlhint`. To install a global version on the current machine, run `npm install --global htmlhint`.
 

--- a/htmlhint/package-lock.json
+++ b/htmlhint/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "vscode-htmlhint",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-htmlhint",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "bundleDependencies": [
         "vscode-languageclient",
         "htmlhint",
         "strip-json-comments",
-        "vscode-languageserver"
+        "vscode-languageserver",
+        "vscode-languageserver-textdocument"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {

--- a/htmlhint/package.json
+++ b/htmlhint/package.json
@@ -3,7 +3,7 @@
   "displayName": "HTMLHint",
   "description": "VS Code integration for HTMLHint - A Static Code Analysis Tool for HTML",
   "icon": "images/icon.png",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "publisher": "HTMLHint",
   "galleryBanner": {
     "color": "#333333",


### PR DESCRIPTION

What I Added:

Core Infrastructure:
Added CodeActionProvider capability to the language server
Imported necessary VS Code Language Server Protocol modules for code actions
Enhanced diagnostics with metadata needed for auto-fixes

Auto-Fix Rules Implemented:
- html-lang-require: Automatically adds lang="en" attribute to <html> tags
- title-require: Adds <title>Document</title> tag in the document head
- attr-value-double-quotes: Converts single quotes to double quotes in HTML attributes

Key Features:
Smart positioning: Auto-fixes insert content in appropriate locations (e.g., title after meta charset)
Safe transformations: Only makes minimal, targeted changes
Extensible architecture: Easy to add more auto-fix rules in the future

How It Works:
Detection: When HTMLHint finds violations, diagnostics now include rule metadata
Code Actions: VS Code shows the lightbulb (💡) icon for fixable issues
Auto-Fix: Users can apply fixes via:
Clicking the lightbulb icon
Keyboard shortcuts (Ctrl+. / Cmd+.)
Right-click context menu
"Fix All" commands

Files Modified:
htmlhint-server/src/server.ts: Added complete auto-fix infrastructure
Enhanced makeDiagnostic() to include rule metadata
Added createHtmlLangRequireFix(), createTitleRequireFix(), createAttrValueDoubleQuotesFix()
Implemented createAutoFixes() with extensible rule handling
Added onCodeAction() handler