### PR TITLE
Fix: Race Condition & Add Debug Logging

### DIFF
--- a/htmlhint/CHANGELOG.md
+++ b/htmlhint/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 All notable changes to the "vscode-htmlhint" extension will be documented in this file.
 
-### v1.6.3 (2025-06-13)
+### v1.7.0 (2025-06-13)
 
 - Add autofix for `meta-description-require`
+- Improve HTMLHint config loading
+- Enable Debug Logging (check the Output > HTMLHint channel in VS Code)
 
 ### v1.6.2 (2025-06-12)
 

--- a/htmlhint/extension.ts
+++ b/htmlhint/extension.ts
@@ -40,7 +40,10 @@ export async function activate(_context: ExtensionContext) {
     diagnosticCollectionName: "htmlhint",
     synchronize: {
       configurationSection: "htmlhint",
-      fileEvents: workspace.createFileSystemWatcher("**/.htmlhintrc"),
+      fileEvents: [
+        workspace.createFileSystemWatcher("**/.htmlhintrc"),
+        workspace.createFileSystemWatcher("**/.htmlhintrc.json"),
+      ],
     },
   };
 

--- a/htmlhint/package-lock.json
+++ b/htmlhint/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-htmlhint",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-htmlhint",
-      "version": "1.6.3",
+      "version": "1.7.0",
       "bundleDependencies": [
         "vscode-languageclient",
         "htmlhint",

--- a/htmlhint/package.json
+++ b/htmlhint/package.json
@@ -3,7 +3,7 @@
   "displayName": "HTMLHint",
   "description": "VS Code integration for HTMLHint - A Static Code Analysis Tool for HTML",
   "icon": "images/icon.png",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "publisher": "HTMLHint",
   "galleryBanner": {
     "color": "#333333",


### PR DESCRIPTION
These changes should resolve the issue where HTMLHint configuration files were not being read properly and the extension was falling back to default rules. The race condition fix in particular should solve the primary issue.