### PR TITLE
fix: config path loading logic

### DIFF
--- a/htmlhint-server/src/server.ts
+++ b/htmlhint-server/src/server.ts
@@ -216,23 +216,31 @@ function findConfigForHtmlFile(base: string) {
     }
 
     while (base && base.length > 0) {
-      let tmpConfigFile = path.resolve(base + path.sep, ".htmlhintrc");
-      trace(`[HTMLHint Debug] Checking config path: ${tmpConfigFile}`);
+      // Check for both .htmlhintrc and .htmlhintrc.json files
+      const configFiles = [
+        path.resolve(base, ".htmlhintrc"),
+        path.resolve(base, ".htmlhintrc.json"),
+      ];
 
-      // undefined means we haven't tried to load the config file at this path, so try to load it.
-      if (htmlhintrcOptions[tmpConfigFile] === undefined) {
-        htmlhintrcOptions[tmpConfigFile] = loadConfigurationFile(tmpConfigFile);
-      }
+      for (const tmpConfigFile of configFiles) {
+        trace(`[HTMLHint Debug] Checking config path: ${tmpConfigFile}`);
 
-      // defined, non-null value means we found a config file at the given path, so use it.
-      if (htmlhintrcOptions[tmpConfigFile]) {
-        options = htmlhintrcOptions[tmpConfigFile];
-        trace(`[HTMLHint Debug] Using config from: ${tmpConfigFile}`);
-        break;
+        // undefined means we haven't tried to load the config file at this path, so try to load it.
+        if (htmlhintrcOptions[tmpConfigFile] === undefined) {
+          htmlhintrcOptions[tmpConfigFile] =
+            loadConfigurationFile(tmpConfigFile);
+        }
+
+        // defined, non-null value means we found a config file at the given path, so use it.
+        if (htmlhintrcOptions[tmpConfigFile]) {
+          options = htmlhintrcOptions[tmpConfigFile];
+          trace(`[HTMLHint Debug] Using config from: ${tmpConfigFile}`);
+          return options;
+        }
       }
 
       // Move to parent directory
-      let parentBase = base.substring(0, base.lastIndexOf(path.sep));
+      let parentBase = path.dirname(base);
       if (parentBase === base) {
         // Reached root directory, stop searching
         break;


### PR DESCRIPTION
I've successfully fixed the HTMLHint configuration discovery logic. 

Here's what was improved:

**Issues Fixed:**

Path Resolution: Changed from path.resolve(base + path.sep, ".htmlhintrc") to the more reliable path.resolve(base, ".htmlhintrc")
Support for Both Config File Types: The extension now searches for both .htmlhintrc and .htmlhintrc.json files
Better Directory Traversal: Replaced manual string manipulation with path.dirname(base) for moving to parent directories
Performance Optimization: Added early return when a config file is found instead of continuing the loop

**How It Now Works:**

✅ Same folder: First checks for .htmlhintrc and .htmlhintrc.json in the HTML file's directory
✅ Parent directories: If no config found, moves up one level at a time through parent directories
✅ Default rules: If no configuration file is found anywhere in the directory tree, uses HTMLHint's default rules
✅ Caching: Configuration files are cached to improve performance

The configuration discovery now properly follows the standard behavior expected by developers - searching from the current file's location up through the directory tree until it finds a configuration file, then falling back to defaults if none is found.