### PR TITLE
chore: Use vscode-uri

### DIFF
--- a/htmlhint-server/package-lock.json
+++ b/htmlhint-server/package-lock.json
@@ -11,7 +11,8 @@
         "htmlhint": "^1.5.1",
         "strip-json-comments": "3.1.1",
         "vscode-languageserver": "9.0.1",
-        "vscode-languageserver-textdocument": "^1.0.12"
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-uri": "^3.1.0"
       },
       "devDependencies": {
         "@types/node": "22.15.31",
@@ -390,6 +391,12 @@
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/htmlhint-server/package.json
+++ b/htmlhint-server/package.json
@@ -11,7 +11,8 @@
     "htmlhint": "^1.5.1",
     "strip-json-comments": "3.1.1",
     "vscode-languageserver": "9.0.1",
-    "vscode-languageserver-textdocument": "^1.0.12"
+    "vscode-languageserver-textdocument": "^1.0.12",
+    "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
     "@types/node": "22.15.31",

--- a/htmlhint-server/src/server.ts
+++ b/htmlhint-server/src/server.ts
@@ -41,6 +41,7 @@ import {
 import { TextDocument } from "vscode-languageserver-textdocument";
 import * as htmlhint from "htmlhint";
 import fs = require("fs");
+import { URI } from "vscode-uri";
 let stripJsonComments: any = require("strip-json-comments");
 
 interface Settings {
@@ -1481,13 +1482,8 @@ function doValidate(connection: Connection, document: TextDocument): void {
     }
 
     let uri = document.uri;
-    // Convert URI to file path manually since Files API is not available
-    let fsPath = uri.replace(/^file:\/\//, "");
-    // Decode URL encoding (e.g., %3A -> :)
-    fsPath = decodeURIComponent(fsPath);
-    if (process.platform === "win32" && fsPath.startsWith("/")) {
-      fsPath = fsPath.substring(1);
-    }
+    // Convert URI to file path using vscode-uri
+    let fsPath = URI.parse(uri).fsPath;
 
     trace(`[DEBUG] doValidate called for: ${fsPath}`);
 
@@ -1578,14 +1574,9 @@ connection.onDidChangeWatchedFiles((params) => {
   let shouldRevalidate = false;
 
   for (let i = 0; i < params.changes.length; i++) {
-    // Convert URI to file path manually since Files API is not available
+    // Convert URI to file path using vscode-uri
     let uri = params.changes[i].uri;
-    let fsPath = uri.replace(/^file:\/\//, "");
-    // Decode URL encoding (e.g., %3A -> :)
-    fsPath = decodeURIComponent(fsPath);
-    if (process.platform === "win32" && fsPath.startsWith("/")) {
-      fsPath = fsPath.substring(1);
-    }
+    let fsPath = URI.parse(uri).fsPath;
 
     trace(`[DEBUG] Processing config file change: ${fsPath}`);
     trace(`[DEBUG] Change type: ${params.changes[i].type}`);

--- a/htmlhint/package.json
+++ b/htmlhint/package.json
@@ -76,19 +76,19 @@
     "vscode:prepublish": "npm run compile && npm run bundle-dependencies",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "bundle-dependencies": "npm install --no-package-lock --no-save htmlhint@^1.5.1 strip-json-comments@3.1.1 vscode-languageserver@9.0.1 vscode-languageserver-textdocument@^1.0.12",
+    "bundle-dependencies": "npm install --no-package-lock --no-save htmlhint@^1.5.1 strip-json-comments@3.1.1 vscode-languageserver@9.0.1 vscode-languageserver-textdocument@^1.0.12 vscode-uri@^3.1.0",
     "package": "vsce package"
   },
   "devDependencies": {
-    "typescript": "^5.2.2",
     "@types/node": "^22.15.31",
     "@types/vscode": "^1.89.0",
+    "typescript": "^5.2.2",
     "vscode-test": "^1.6.1"
   },
   "dependencies": {
-    "vscode-languageclient": "9.0.1",
     "htmlhint": "^1.5.1",
     "strip-json-comments": "3.1.1",
+    "vscode-languageclient": "9.0.1",
     "vscode-languageserver": "9.0.1"
   },
   "bundleDependencies": [


### PR DESCRIPTION
Fixes: #58

These changes are much cleaner and more reliable now. The vscode-uri package handles all the edge cases for us, including:

- Proper URI parsing
- URL decoding
- Platform-specific path handling
- Proper handling of file:// protocol