### PR TITLE
feat: Autofix `tag-self-close` rule

### DIFF
--- a/htmlhint/CHANGELOG.md
+++ b/htmlhint/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the "vscode-htmlhint" extension will be documented in thi
 ### v1.10.2 (2025-06-19)
 
 - Add autofix for `spec-char-escape` rule
+- Add autofix for `tag-self-close` rule
 - Rename extension output channel to "HTMLHint Extension" for better debugging
 
 ### v1.10.1 (2025-06-19)

--- a/htmlhint/README.md
+++ b/htmlhint/README.md
@@ -38,6 +38,7 @@ The extension provides automatic fixes for many common HTML issues. Currently su
 - **`meta-description-require`** - Adds description meta tag
 - **`meta-viewport-require`** - Adds viewport meta tag
 - **`spec-char-escape`** - Escapes special characters (`<`, `>`)
+- **`tag-self-close`** - Converts self-closable tags to self-closing tags
 - **`tagname-lowercase`** - Converts uppercase tag names to lowercase
 - **`title-require`** - Adds `<title>` tag to document
 

--- a/test/autofix/.htmlhintrc
+++ b/test/autofix/.htmlhintrc
@@ -15,7 +15,7 @@
   "spec-char-escape": true,
   "src-not-empty": true,
   "tag-pair": true,
-  "tag-self-close": false,
+  "tag-self-close": true,
   "tagname-lowercase": true,
   "title-require": true
 }

--- a/test/autofix/tag-self-close-test.html
+++ b/test/autofix/tag-self-close-test.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Tag Self-Close Test" />
+    <title>Tag Self-Close Test</title>
+  </head>
+  <body>
+    <!-- These tags should be self-closing -->
+    <img src="test.jpg" alt="Test image">
+    <br>
+    <hr>
+    <input type="text" placeholder="Enter text">
+    <meta name="test" content="test">
+    <link rel="stylesheet" href="style.css">
+
+    <!-- These are already self-closing -->
+    <img src="test2.jpg" alt="Test image 2" />
+    <br />
+    <hr />
+    <input type="email" placeholder="Enter email" />
+  </body>
+</html>

--- a/test/autofix/test-autofixes.html
+++ b/test/autofix/test-autofixes.html
@@ -30,6 +30,14 @@
         <span style="color: red">Test</span>
       </div>
 
+      <!-- These tags should be self-closing -->
+      <img src="test.jpg" alt="Test image">
+      <br>
+      <hr>
+      <input type="text" placeholder="Enter text">
+      <meta name="test" content="test">
+      <link rel="stylesheet" href="style.css">
+
       <!-- Mix of issues -->
       <p class =" paragraph" id = "para1">
         This is a test paragraph with <a href="link.html">a link</a>.


### PR DESCRIPTION
This pull request introduces a new autofix feature for the `tag-self-close` rule in the `htmlhint-server` and refactors existing code to simplify and improve maintainability. It also includes updates to the documentation and test cases to reflect the new functionality.

### New Feature: `tag-self-close` Autofix
* Added `createTagSelfCloseFix` function to automatically convert non-self-closing void HTML elements (e.g., `<img>`) into self-closing tags (e.g., `<img />`) to comply with standards. (`htmlhint-server/src/server.ts`, [htmlhint-server/src/server.tsR1342-R1468](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbR1342-R1468))
* Integrated the new autofix into the `createAutoFixes` function, enabling it to handle diagnostics for the `tag-self-close` rule. (`htmlhint-server/src/server.ts`, [htmlhint-server/src/server.tsR1551-R1554](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbR1551-R1554))
* Updated the diagnostic handling logic in `connection.onRequest` to support the `tag-self-close` rule, including extracting raw tag data and ensuring proper range normalization. (`htmlhint-server/src/server.ts`, [[1]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbR1815-R1848) [[2]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbL1739-R1886) [[3]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbL1755-R1907) [[4]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbL1769-R1922)

### Code Refactoring
* Simplified position calculations in multiple autofix functions (`createAttrValueDoubleQuotesFix`, `createTagnameLowercaseFix`, `createAttrLowercaseFix`, and `createSpecCharEscapeFix`) by replacing complex logic with a more direct approach using `lineIndex`. (`htmlhint-server/src/server.ts`, [[1]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbL541-R543) [[2]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbL613-R610) [[3]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbL685-R677) [[4]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbL1318-R1305)

### Documentation Updates
* Added the `tag-self-close` rule to the list of supported autofix rules in the `README.md` file. (`htmlhint/README.md`, [htmlhint/README.mdR41](diffhunk://#diff-bf5939ac4591991a2798478499c76d8c5a6353b6371b7a6b2f91053e9d0e0097R41))
* Updated the `CHANGELOG.md` to document the addition of the `tag-self-close` autofix feature. (`htmlhint/CHANGELOG.md`, [htmlhint/CHANGELOG.mdR8](diffhunk://#diff-01ccc4ce37399d777b8612cf4c911747cc3b730c087a8596adf2c03f8decbb6aR8))

### Test Enhancements
* Enabled the `tag-self-close` rule in the `.htmlhintrc` configuration file for testing. (`test/autofix/.htmlhintrc`, [test/autofix/.htmlhintrcL18-R18](diffhunk://#diff-cce0605a5fa017b9d50698cd42f226c6aebf0f72c2e638a39c6cc5a38e119dd8L18-R18))
* Added new test cases in `tag-self-close-test.html` to validate the autofix functionality for various scenarios. (`test/autofix/tag-self-close-test.html`, [test/autofix/tag-self-close-test.htmlR1-R24](diffhunk://#diff-86c402db08b151804dc1a24e08fff4470e6a88d1b92ba35bea50e76e7980e445R1-R24))
* Included additional `tag-self-close` test cases in the existing `test-autofixes.html` file. (`test/autofix/test-autofixes.html`, [test/autofix/test-autofixes.htmlR33-R40](diffhunk://#diff-081898529d699141caa10d49e3a2f93fe967e6bc4d50564d4104e63386d0a891R33-R40))