### PR TITLE
feat: add .gitignore option

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -1,0 +1,10 @@
+---
+description:
+globs:
+alwaysApply: true
+---
+- Before declaring a task is complete, compile the extension to ensure it completes with no errors.
+- Never downgrade dependencies
+- Always run commands using PowerShell on Windows
+- Newly added version/features for the Extension Changelog go at the top.
+- As a general rule: rules, attributes, lists shoud be alphabetical order.

--- a/htmlhint-server/src/server.ts
+++ b/htmlhint-server/src/server.ts
@@ -43,7 +43,11 @@ import { TextDocument } from "vscode-languageserver-textdocument";
 import * as htmlhint from "htmlhint";
 import fs = require("fs");
 import { URI } from "vscode-uri";
+import ignore from "ignore";
 let stripJsonComments: any = require("strip-json-comments");
+
+// Cache for gitignore patterns to avoid repeatedly parsing .gitignore files
+let gitignoreCache: Map<string, any> = new Map();
 
 interface Settings {
   htmlhint: {
@@ -51,6 +55,7 @@ interface Settings {
     enable: boolean;
     options: any;
     optionsFile: string;
+    ignoreGitignore: boolean;
   };
   [key: string]: any;
 }
@@ -1665,6 +1670,8 @@ async function createAutoFixes(
   }
 
   trace(`[DEBUG] Returning ${actions.length} auto-fix actions`);
+  trace(`[DEBUG] Code actions: ${JSON.stringify(actions)}`);
+
   return actions;
 }
 
@@ -1723,6 +1730,7 @@ connection.onInitialized(() => {
           options: {},
           configFile: "",
           optionsFile: "",
+          ignoreGitignore: false,
         },
       };
       validateAllTextDocuments(connection, documents.all());
@@ -1742,6 +1750,20 @@ function doValidate(connection: Connection, document: TextDocument): void {
     let fsPath = URI.parse(uri).fsPath;
 
     trace(`[DEBUG] doValidate called for: ${fsPath}`);
+
+    // Check if file should be ignored based on .gitignore
+    if (settings.htmlhint.ignoreGitignore) {
+      // Find workspace root by looking for .git directory or .gitignore file
+      let workspaceRoot = findWorkspaceRoot(fsPath);
+      if (workspaceRoot && shouldIgnoreFile(fsPath, workspaceRoot)) {
+        trace(
+          `[DEBUG] File ${fsPath} is ignored by .gitignore, skipping validation`,
+        );
+        // Clear any existing diagnostics for this file
+        connection.sendDiagnostics({ uri, diagnostics: [] });
+        return;
+      }
+    }
 
     let contents = document.getText();
     let lines = contents.split("\n");
@@ -1807,6 +1829,9 @@ connection.onDidChangeConfiguration((params) => {
         htmlhintrcOptions[configPath] = undefined;
       });
 
+      // Clear gitignore cache when settings change
+      gitignoreCache.clear();
+
       trace(`[DEBUG] Triggering revalidation due to settings change`);
       validateAllTextDocuments(connection, documents.all());
     })
@@ -1818,6 +1843,7 @@ connection.onDidChangeConfiguration((params) => {
         Object.keys(htmlhintrcOptions).forEach((configPath) => {
           htmlhintrcOptions[configPath] = undefined;
         });
+        gitignoreCache.clear();
         validateAllTextDocuments(connection, documents.all());
       }
     });
@@ -1837,7 +1863,7 @@ connection.onDidChangeWatchedFiles((params) => {
     trace(`[DEBUG] Processing config file change: ${fsPath}`);
     trace(`[DEBUG] Change type: ${params.changes[i].type}`);
 
-    // Only process .htmlhintrc files
+    // Process .htmlhintrc files
     if (fsPath.endsWith(".htmlhintrc") || fsPath.endsWith(".htmlhintrc.json")) {
       shouldRevalidate = true;
 
@@ -1859,6 +1885,15 @@ connection.onDidChangeWatchedFiles((params) => {
         htmlhintrcOptions[configPath] = undefined;
       });
     }
+
+    // Process .gitignore files
+    if (fsPath.endsWith(".gitignore")) {
+      shouldRevalidate = true;
+
+      // Clear gitignore cache when .gitignore changes
+      trace(`[DEBUG] .gitignore file changed, clearing cache`);
+      gitignoreCache.clear();
+    }
   }
 
   if (shouldRevalidate) {
@@ -1866,7 +1901,7 @@ connection.onDidChangeWatchedFiles((params) => {
     // Force revalidation of all documents
     validateAllTextDocuments(connection, documents.all());
   } else {
-    trace(`[DEBUG] No .htmlhintrc files changed, skipping revalidation`);
+    trace(`[DEBUG] No relevant files changed, skipping revalidation`);
   }
 });
 
@@ -2034,3 +2069,70 @@ connection.onRequest(
 );
 
 connection.listen();
+
+/**
+ * Check if a file should be ignored based on .gitignore patterns
+ */
+function shouldIgnoreFile(filePath: string, workspaceRoot: string): boolean {
+  try {
+    // Find the .gitignore file in the workspace root
+    const gitignorePath = path.join(workspaceRoot, ".gitignore");
+
+    if (!fs.existsSync(gitignorePath)) {
+      return false; // No .gitignore file, so don't ignore anything
+    }
+
+    // Check cache first
+    if (gitignoreCache.has(workspaceRoot)) {
+      const ig = gitignoreCache.get(workspaceRoot);
+      const relativePath = path.relative(workspaceRoot, filePath);
+      return ig.ignores(relativePath);
+    }
+
+    // Parse .gitignore file
+    const gitignoreContent = fs.readFileSync(gitignorePath, "utf8");
+    const ig = ignore().add(gitignoreContent);
+
+    // Cache the parsed patterns
+    gitignoreCache.set(workspaceRoot, ig);
+
+    // Check if the file should be ignored
+    const relativePath = path.relative(workspaceRoot, filePath);
+    return ig.ignores(relativePath);
+  } catch (error) {
+    trace(`[DEBUG] Error checking .gitignore for ${filePath}: ${error}`);
+    return false; // On error, don't ignore the file
+  }
+}
+
+/**
+ * Find the workspace root directory by looking for .git directory or .gitignore file
+ */
+function findWorkspaceRoot(filePath: string): string | null {
+  try {
+    let currentDir = path.dirname(filePath);
+    const rootDir = path.parse(filePath).root;
+
+    while (currentDir !== rootDir) {
+      // Check for .git directory or .gitignore file
+      if (
+        fs.existsSync(path.join(currentDir, ".git")) ||
+        fs.existsSync(path.join(currentDir, ".gitignore"))
+      ) {
+        return currentDir;
+      }
+
+      // Move up one directory
+      const parentDir = path.dirname(currentDir);
+      if (parentDir === currentDir) {
+        break; // Reached root
+      }
+      currentDir = parentDir;
+    }
+
+    return null; // No workspace root found
+  } catch (error) {
+    trace(`[DEBUG] Error finding workspace root for ${filePath}: ${error}`);
+    return null;
+  }
+}

--- a/htmlhint/.vscodeignore
+++ b/htmlhint/.vscodeignore
@@ -41,6 +41,7 @@ images/status-bar.png
 **/node_modules/**/*.md
 **/node_modules/**/*.txt
 **/node_modules/**/LICENSE*
+**/node_modules/**/LICENSE-MIT*
 **/node_modules/**/license*
 **/node_modules/**/CHANGELOG*
 **/node_modules/**/changelog*

--- a/htmlhint/CHANGELOG.md
+++ b/htmlhint/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 All notable changes to the "vscode-htmlhint" extension will be documented in this file.
 
-### v1.10.3 (2025-06-20)
+### v1.11.0 (2025-06-20)
 
+- Option to skip linting files ignored by `.gitignore` (`htmlhint.ignoreGitignore`).
+  - When enabled, HTMLHint will not lint files or folders listed in your workspace's `.gitignore` (e.g., `node_modules/`, `dist/`, etc).
+  - Enable this in VS Code settings: `HTMLHint: Ignore Gitignore`.
 - Add autofix for `attr-whitespace` rule
 
 ### v1.10.2 (2025-06-19)

--- a/htmlhint/README.md
+++ b/htmlhint/README.md
@@ -125,3 +125,28 @@ Here's an example using the `htmlhint.documentSelector` and `htmlhint.options` s
   "title-require": true
 }
 ```
+
+## Skipping Linting for `.gitignore`-d Files
+
+You can configure the extension to **skip linting files and folders that are listed in your `.gitignore`**. This is useful for ignoring generated files, dependencies, and other files you don't want to lint (like `node_modules/`, `dist/`, `build/`, etc).
+
+### How to Enable
+
+1. Open VS Code settings.
+2. Search for `HTMLHint: Ignore Gitignore`.
+3. Enable the option:
+   **`htmlhint.ignoreGitignore`** (default: `false`)
+
+When enabled, any HTML files ignored by your workspace's `.gitignore` will not be linted by the extension.
+
+### Example
+
+If your `.gitignore` contains:
+
+```
+node_modules/
+dist/
+*.tmp
+```
+
+Then files like `dist/index.html` or `node_modules/foo/bar.html` will be skipped by HTMLHint.

--- a/htmlhint/extension.ts
+++ b/htmlhint/extension.ts
@@ -58,6 +58,7 @@ export function activate(context: vscode.ExtensionContext) {
       fileEvents: [
         vscode.workspace.createFileSystemWatcher("**/.htmlhintrc"),
         vscode.workspace.createFileSystemWatcher("**/.htmlhintrc.json"),
+        vscode.workspace.createFileSystemWatcher("**/.gitignore"),
       ],
     },
     middleware: {

--- a/htmlhint/package-lock.json
+++ b/htmlhint/package-lock.json
@@ -1,23 +1,25 @@
 {
   "name": "vscode-htmlhint",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-htmlhint",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "bundleDependencies": [
         "vscode-languageclient",
         "htmlhint",
         "strip-json-comments",
         "vscode-languageserver",
         "vscode-languageserver-textdocument",
-        "vscode-uri"
+        "vscode-uri",
+        "ignore"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "htmlhint": "1.6.3",
+        "ignore": "^5.2.2",
         "strip-json-comments": "3.1.1",
         "vscode-languageclient": "9.0.1",
         "vscode-languageserver": "9.0.1",
@@ -464,6 +466,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.2.tgz",
+      "integrity": "sha512-m1MJSy4Z2NAcyhoYpxQeBsc1ZdNQwYjN0wGbLBlnVArdJ90Gtr8IhNSfZZcCoR0fM/0E0BJ0mf1KnLNDOCJP4w==",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/inflight": {

--- a/htmlhint/package.json
+++ b/htmlhint/package.json
@@ -3,7 +3,7 @@
   "displayName": "HTMLHint",
   "description": "VS Code integration for HTMLHint - A Static Code Analysis Tool for HTML",
   "icon": "images/icon.png",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "publisher": "HTMLHint",
   "galleryBanner": {
     "color": "#333333",
@@ -66,6 +66,11 @@
           "type": "string",
           "default": null,
           "description": "The HTMLHint options config file path."
+        },
+        "htmlhint.ignoreGitignore": {
+          "type": "boolean",
+          "default": false,
+          "description": "Skip linting files that are ignored by .gitignore. This is useful to avoid linting generated files, dependencies, and other files that shouldn't be checked."
         }
       }
     },
@@ -82,7 +87,7 @@
     "vscode:prepublish": "npm run compile && npm run bundle-dependencies",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "bundle-dependencies": "npm install --no-package-lock --no-save --no-fund htmlhint@1.6.3 strip-json-comments@3.1.1 vscode-languageserver@9.0.1 vscode-languageserver-textdocument@1.0.12 vscode-uri@3.1.0",
+    "bundle-dependencies": "npm install --no-package-lock --no-save --no-fund htmlhint@1.6.3 strip-json-comments@3.1.1 vscode-languageserver@9.0.1 vscode-languageserver-textdocument@1.0.12 vscode-uri@3.1.0 ignore@5.2.2",
     "package": "vsce package"
   },
   "devDependencies": {
@@ -93,6 +98,7 @@
   },
   "dependencies": {
     "htmlhint": "1.6.3",
+    "ignore": "^5.2.2",
     "strip-json-comments": "3.1.1",
     "vscode-languageclient": "9.0.1",
     "vscode-languageserver": "9.0.1",
@@ -105,7 +111,8 @@
     "strip-json-comments",
     "vscode-languageserver",
     "vscode-languageserver-textdocument",
-    "vscode-uri"
+    "vscode-uri",
+    "ignore"
   ],
   "volta": {
     "node": "22.16.0"


### PR DESCRIPTION
This pull request introduces a new feature to the `vscode-htmlhint` extension, allowing users to skip linting files ignored by `.gitignore`. It also includes updates to handle `.gitignore` files, improve diagnostics, and update dependencies. Below is a summary of the most important changes:

### New Feature: `.gitignore` Integration
* Added a new configuration option `htmlhint.ignoreGitignore` to skip linting files ignored by `.gitignore`. This feature can be enabled in VS Code settings. [[1]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbR1733) [[2]](diffhunk://#diff-08c2e20c51c924a1a15c0665ca960ca23af45ddd76dbfcd4a52f86d17ce8f066R69-R73) [[3]](diffhunk://#diff-bf5939ac4591991a2798478499c76d8c5a6353b6371b7a6b2f91053e9d0e0097R128-R152) [[4]](diffhunk://#diff-01ccc4ce37399d777b8612cf4c911747cc3b730c087a8596adf2c03f8decbb6aL5-R9)
* Implemented logic to parse `.gitignore` files and determine whether files should be ignored during validation. This includes caching for performance and clearing the cache when settings or `.gitignore` files change. [[1]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbR46-R58) [[2]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbR1754-R1767) [[3]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbR1832-R1834) [[4]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbR1888-R1904) [[5]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbR2072-R2138)

### Diagnostics and Debugging Enhancements
* Added debug logging for code actions and `.gitignore`-related operations to improve traceability. [[1]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbR1673-R1674) [[2]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbR1888-R1904)
* Updated validation logic to clear diagnostics for ignored files, ensuring no unnecessary warnings are displayed.

### Dependency and Configuration Updates
* Updated `package.json` and `package-lock.json` to include the `ignore` library for `.gitignore` handling. [[1]](diffhunk://#diff-08c2e20c51c924a1a15c0665ca960ca23af45ddd76dbfcd4a52f86d17ce8f066R101) [[2]](diffhunk://#diff-a19104f66b89f91fe059f01749d74668bde853816ad7a3407335eb08433ac08cR471-R480)
* Bumped the extension version to `1.11.0` and updated the changelog to document the new feature. [[1]](diffhunk://#diff-08c2e20c51c924a1a15c0665ca960ca23af45ddd76dbfcd4a52f86d17ce8f066L6-R6) [[2]](diffhunk://#diff-01ccc4ce37399d777b8612cf4c911747cc3b730c087a8596adf2c03f8decbb6aL5-R9)

### File Watcher Enhancements
* Added a file system watcher for `.gitignore` files to trigger revalidation when they are modified. [[1]](diffhunk://#diff-1ac0bb0f50384f40281456f9d617a0a26d5b0bc6f415600967b97468608d76c7R61) [[2]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbR1888-R1904)

### General Codebase Improvements
* Updated `.cursor/rules/general.mdc` with guidelines for maintaining alphabetical order in rules, attributes, and lists.