### PR TITLE
Reduce package size

### DIFF
--- a/htmlhint/.vscodeignore
+++ b/htmlhint/.vscodeignore
@@ -36,6 +36,12 @@
 images/hero.png
 images/hover.png
 images/status-bar.png
+**/node_modules/async/**
+**/node_modules/htmlhint/dist/htmlhint.min.js
+**/node_modules/htmlhint/cli/formatter.js
+**/node_modules/htmlhint/cli/htmlhint.js
+**/node_modules/htmlhint/cli/parse-glob.js
+**/node_modules/htmlhint/cli/formatters/**
 **/node_modules/**/test/**
 **/node_modules/**/tests/**
 **/node_modules/**/*.md
@@ -48,6 +54,9 @@ images/status-bar.png
 **/node_modules/**/*.map
 **/node_modules/**/.bin/**
 **/node_modules/**/bin/**
+**/node_modules/**/copy/**
+**/node_modules/**/move/**
+**/node_modules/**/empty/**
 **/node_modules/**/*.cmd
 **/node_modules/**/*.ps1
 **/node_modules/**/*.sh


### PR DESCRIPTION
This reduces package size from 804 KB to 568 KB!

This pull request updates the `.vscodeignore` file in the `htmlhint` project to exclude additional files and directories from being included in the VS Code extension package. The changes aim to reduce the package size by ignoring unnecessary files.

### Updates to `.vscodeignore`:

* Added exclusions for specific directories and files in `node_modules`, such as `async`, `htmlhint/dist/htmlhint.min.js`, and several CLI-related files (`formatter.js`, `htmlhint.js`, `parse-glob.js`, and the `formatters` directory).
* Added exclusions for additional directories like `copy`, `move`, and `empty` under `node_modules`.