### PR TITLE
feat: add `tag-no-obsolete` autofix

### DIFF
--- a/htmlhint/CHANGELOG.md
+++ b/htmlhint/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "vscode-htmlhint" extension will be documented in this file.
 
+### v1.11.1 (2025-06-23)
+
+- Add autofix for `tag-no-obsolete` rule
+
 ### v1.11.0 (2025-06-20)
 
 - Option to skip linting files ignored by `.gitignore` (`htmlhint.ignoreGitignore`).

--- a/htmlhint/README.md
+++ b/htmlhint/README.md
@@ -39,6 +39,7 @@ The extension provides automatic fixes for many common HTML issues. Currently su
 - **`meta-description-require`** - Adds description meta tag
 - **`meta-viewport-require`** - Adds viewport meta tag
 - **`spec-char-escape`** - Escapes special characters (`<`, `>`)
+- **`tag-no-obsolete`** - Converts obsolete tags to modern equivalents (e.g., `<acronym>` to `<abbr>`)
 - **`tag-self-close`** - Converts self-closable tags to self-closing tags
 - **`tagname-lowercase`** - Converts uppercase tag names to lowercase
 - **`title-require`** - Adds `<title>` tag to document

--- a/test/autofix/.htmlhintrc
+++ b/test/autofix/.htmlhintrc
@@ -15,6 +15,7 @@
   "meta-viewport-require": true,
   "spec-char-escape": true,
   "src-not-empty": true,
+  "tag-no-obsolete": true,
   "tag-pair": true,
   "tag-self-close": true,
   "tagname-lowercase": true,


### PR DESCRIPTION
This pull request introduces a new auto-fix feature for the `tag-no-obsolete` rule in the `htmlhint-server` project. The feature automatically converts obsolete HTML tags, such as `<acronym>`, to their modern equivalents, like `<abbr>`. Updates include the implementation of the fix logic, integration into the auto-fix pipeline, and documentation changes to reflect the new functionality.

### Implementation of `tag-no-obsolete` auto-fix:

* [`htmlhint-server/src/server.ts`](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbR1569-R1788): Added the `createTagNoObsoleteFix` function to identify and convert obsolete `<acronym>` tags to `<abbr>` tags. The function handles opening, closing, and self-closing tags, ensuring accurate replacements. Helper functions `findOpeningTag` and `findClosingTag` were also added to support tag matching.

### Integration into auto-fix pipeline:

* [`htmlhint-server/src/server.ts`](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbR1879-R1882): Updated the `createAutoFixes` function to call `createTagNoObsoleteFix` when the `tag-no-obsolete` rule is triggered.

### Documentation updates:

* [`htmlhint/CHANGELOG.md`](diffhunk://#diff-01ccc4ce37399d777b8612cf4c911747cc3b730c087a8596adf2c03f8decbb6aR5-R8): Documented the addition of the `tag-no-obsolete` auto-fix feature in version `v1.11.1`.
* [`htmlhint/README.md`](diffhunk://#diff-bf5939ac4591991a2798478499c76d8c5a6353b6371b7a6b2f91053e9d0e0097R42): Updated the list of supported rules to include the `tag-no-obsolete` rule, with a description of its functionality.

### Configuration updates:

* [`test/autofix/.htmlhintrc`](diffhunk://#diff-cce0605a5fa017b9d50698cd42f226c6aebf0f72c2e638a39c6cc5a38e119dd8R18): Enabled the `tag-no-obsolete` rule in the `.htmlhintrc` configuration file for testing purposes.