### PR TITLE
fix: remove unused and deprecated rootPath variable

### DIFF
--- a/htmlhint-server/src/server.ts
+++ b/htmlhint-server/src/server.ts
@@ -1904,7 +1904,6 @@ async function createAutoFixes(
 
 connection.onInitialize(
   (params: InitializeParams, token: CancellationToken) => {
-    let rootFolder = params.rootPath;
     let initOptions: {
       nodePath: string;
     } = params.initializationOptions;


### PR DESCRIPTION
This pull request includes a minor change to the `htmlhint-server/src/server.ts` file. The change removes an unused variable `rootFolder` from the `onInitialize` function to improve code clarity.