### PR TITLE
Smarter autofix for rules which accommodates for `tag-self-close` rule.

### DIFF
--- a/htmlhint/CHANGELOG.md
+++ b/htmlhint/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "vscode-htmlhint" extension will be documented in this file.
 
+### v1.15.0 (2025-11-27)
+
+- Smarter autofix for rules which accommodates for `tag-self-close` rule.
+
 ### v1.14.0 (2025-11-26)
 
 - Add autofix for the `attr-no-duplication` rule

--- a/htmlhint/package-lock.json
+++ b/htmlhint/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-htmlhint",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-htmlhint",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "bundleDependencies": [
         "vscode-languageclient",
         "htmlhint",

--- a/htmlhint/package.json
+++ b/htmlhint/package.json
@@ -3,7 +3,7 @@
   "displayName": "HTMLHint",
   "description": "VS Code integration for HTMLHint - A Static Code Analysis Tool for HTML",
   "icon": "images/icon.png",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "publisher": "HTMLHint",
   "galleryBanner": {
     "color": "#333333",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "glob": "^13.0.0",
         "globals": "^16.5.0",
         "mocha": "^11.7.5",
-        "prettier": "3.6.2",
+        "prettier": "3.7.1",
         "ts-node": "^10.9.2",
         "typescript": "5.5.4"
       },
@@ -2359,10 +2359,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.1.tgz",
+      "integrity": "sha512-RWKXE4qB3u5Z6yz7omJkjWwmTfLdcbv44jUVHC5NpfXwFGzvpQM798FGv/6WNK879tc+Cn0AAyherCl1KjbyZQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "description": "VS Code extension to support HTMLHint, an HTML linter.",
-  "homepage": "https://github.com/htmlhint/vscode-htmlhint#readme",
+  "homepage": "https://htmlhint.com",
   "bugs": {
     "url": "https://github.com/htmlhint/vscode-htmlhint/issues"
   },
@@ -43,7 +43,7 @@
     "glob": "^13.0.0",
     "globals": "^16.5.0",
     "mocha": "^11.7.5",
-    "prettier": "3.6.2",
+    "prettier": "3.7.1",
     "ts-node": "^10.9.2",
     "typescript": "5.5.4"
   },


### PR DESCRIPTION

This pull request introduces smarter autofix behavior for HTMLHint rules, specifically making autofixes aware of the `tag-self-close` rule. This ensures that generated `<meta>` tags will be self-closed if the rule is enabled, improving standards compliance and consistency with user configuration. The update also includes a new utility for determining if a rule is enabled for a given document, minor code cleanups, and version/documentation updates.

### Autofix improvements

* Autofix logic for inserting `<meta>` tags (`charset`, `viewport`, `description`) now respects the `tag-self-close` rule, generating self-closing tags if enabled. (`htmlhint-server/src/server.ts`) [[1]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbL792-R855) [[2]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbR912-R933) [[3]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbL926-R1015)
* Added `isHtmlHintRuleEnabled` and `isRuleEnabledForDocument` helpers to robustly determine if a rule (like `tag-self-close`) is enabled for a given document. (`htmlhint-server/src/server.ts`)

### Code maintenance

* Minor formatting and code cleanup in the `createAttrValueNoDuplicationFix` function. (`htmlhint-server/src/server.ts`) [[1]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbL1980-R2047) [[2]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbL1993-R2062) [[3]](diffhunk://#diff-ebd5d4df81281367ec41e0667be3b9ef594012b9faf46c494a318faac2f9d9fbL2020-R2091)

### Version and documentation updates

* Bumped extension version to `1.15.0` and documented new autofix behavior in `CHANGELOG.md`. (`htmlhint/package.json`, `htmlhint/package-lock.json`, `htmlhint/CHANGELOG.md`) [[1]](diffhunk://#diff-08c2e20c51c924a1a15c0665ca960ca23af45ddd76dbfcd4a52f86d17ce8f066L6-R6) [[2]](diffhunk://#diff-a19104f66b89f91fe059f01749d74668bde853816ad7a3407335eb08433ac08cL3-R9) [[3]](diffhunk://#diff-01ccc4ce37399d777b8612cf4c911747cc3b730c087a8596adf2c03f8decbb6aR5-R8)
* Updated project homepage and development dependency (`prettier`) version in `package.json`. (`package.json`) [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L6-R6) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L46-R46)