### PR TITLE
Update TypeScript to 5.6.3 and add Prettier formatting rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,15 @@
 - Never downgrade dependencies.
 - Newly added version/features for the Extension Changelog go at the top.
 - As a general rule: some rules, attributes, lists should be in alphabetical order.
+- Format everything (except HTML) with Prettier.
+
+## Markdown Code Style
+
+- Format with Prettier.
+
+## TypeScript Code Style
+
+- Format with Prettier.
 
 ## Communication (MANDATORY)
 
@@ -28,4 +37,4 @@
 
 - No emojis in code or documentation.
 - Only implement what's requested.
-- Preserve existing structures - Don't remove unrelated code
+- Preserve existing structures - Don't remove unrelated code.

--- a/htmlhint-server/src/server.ts
+++ b/htmlhint-server/src/server.ts
@@ -1074,8 +1074,7 @@ function createLinkRelCanonicalRequireFix(
   let insertPosition: number;
   const shouldSelfClose = isRuleEnabledForDocument(document, "tag-self-close");
   const canonicalSnippet =
-    '\n    <link rel="canonical" href=""' +
-    (shouldSelfClose ? " />" : ">");
+    '\n    <link rel="canonical" href=""' + (shouldSelfClose ? " />" : ">");
 
   if (metaDescriptionMatch) {
     // Insert after description meta tag

--- a/htmlhint/package-lock.json
+++ b/htmlhint/package-lock.json
@@ -29,7 +29,7 @@
         "@types/node": "^22.19.1",
         "@types/vscode": "^1.101.0",
         "@vscode/test-electron": "^2.5.2",
-        "typescript": "5.5.4"
+        "typescript": "5.6.3"
       },
       "engines": {
         "vscode": "^1.101.0"
@@ -852,9 +852,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/htmlhint/package.json
+++ b/htmlhint/package.json
@@ -94,7 +94,7 @@
     "@types/node": "^22.19.1",
     "@types/vscode": "^1.101.0",
     "@vscode/test-electron": "^2.5.2",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   },
   "dependencies": {
     "htmlhint": "1.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "mocha": "^11.7.5",
         "prettier": "3.7.1",
         "ts-node": "^10.9.2",
-        "typescript": "5.5.4"
+        "typescript": "5.6.3"
       },
       "engines": {
         "node": ">= 22"
@@ -2778,9 +2778,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "mocha": "^11.7.5",
     "prettier": "3.7.1",
     "ts-node": "^10.9.2",
-    "typescript": "5.5.4"
+    "typescript": "5.6.3"
   },
   "engines": {
     "node": ">= 22"


### PR DESCRIPTION
Upgraded TypeScript from 5.5.4 to 5.6.3 in all relevant package files. Updated AGENTS.md to specify Prettier as the formatting tool for Markdown and TypeScript code. Minor formatting fix in server.ts.