### PR TITLE
Autofix `doctype-first` is now lowercase

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+.cspell.json
 .vscode-test/
 htmlhint/out/
 htmlhint/server/

--- a/htmlhint-server/src/server.ts
+++ b/htmlhint-server/src/server.ts
@@ -752,7 +752,7 @@ function createDoctypeFirstFix(
 
   // Insert DOCTYPE at the beginning of the document
   const insertPosition = document.positionAt(0);
-  const newText = "<!DOCTYPE html>\n";
+  const newText = "<!doctype html>\n";
 
   const edit: TextEdit = {
     range: {
@@ -803,7 +803,7 @@ function createDoctypeHtml5Fix(
       start: document.positionAt(doctypeStart),
       end: document.positionAt(doctypeEnd),
     },
-    newText: "<!DOCTYPE html>",
+    newText: "<!doctype html>",
   };
 
   const workspaceEdit: WorkspaceEdit = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "glob": "^13.0.0",
         "globals": "^16.5.0",
         "mocha": "^11.7.5",
-        "prettier": "3.7.1",
+        "prettier": "3.7.3",
         "ts-node": "^10.9.2",
         "typescript": "5.6.3"
       },
@@ -2359,9 +2359,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.1.tgz",
-      "integrity": "sha512-RWKXE4qB3u5Z6yz7omJkjWwmTfLdcbv44jUVHC5NpfXwFGzvpQM798FGv/6WNK879tc+Cn0AAyherCl1KjbyZQ==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.3.tgz",
+      "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "npm run compile",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "prettier": "prettier --write \"**/*.{js,md,ts,yml}\"",
+    "prettier": "prettier --write \"**/*.{js,json,md,ts,yml}\"",
     "spellcheck": "npx cspell \"**/*.{html,js,json,md,ts,yml}\"",
     "postinstall": "cd htmlhint && npm i && cd ../htmlhint-server && npm i",
     "compile": "cd htmlhint-server && npm run compile && cd ../htmlhint && npm run compile",
@@ -43,7 +43,7 @@
     "glob": "^13.0.0",
     "globals": "^16.5.0",
     "mocha": "^11.7.5",
-    "prettier": "3.7.1",
+    "prettier": "3.7.3",
     "ts-node": "^10.9.2",
     "typescript": "5.6.3"
   },


### PR DESCRIPTION
standardized DOCTYPE casing in htmlhint-server to lowercase. (matches Prettier v3.x)

Also:
- Upgraded Prettier from 3.7.1 to 3.7.3 in package files.
- Added .cspell.json to .prettierignore and included .json files in the Prettier script for better formatting coverage. 