### PR TITLE
v1.16.0

### DIFF
--- a/htmlhint-server/package-lock.json
+++ b/htmlhint-server/package-lock.json
@@ -8,7 +8,7 @@
       "name": "htmlhint-server",
       "version": "1.0.0",
       "dependencies": {
-        "htmlhint": "^1.8.0",
+        "htmlhint": "^1.8.1",
         "strip-json-comments": "3.1.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.12",
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
-      "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
+      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -166,9 +166,9 @@
       }
     },
     "node_modules/htmlhint": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/htmlhint/-/htmlhint-1.8.0.tgz",
-      "integrity": "sha512-RT1UsSM3ldlVQ7DDqWnbbRY1Rf6wwudmdYwiJzIyZVapA0jcka5r2lE2RkMLzTDN5c8Vc06yis57TaTpZ6o3Dg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/htmlhint/-/htmlhint-1.8.1.tgz",
+      "integrity": "sha512-xNaihALJIBnvPIBQRGlA/T84Ew7RMKduvKqgQeS4pqZ8zLg09CBDc8LYiWQtgvsllE32+fhgBUYesIcuyeDodw==",
       "license": "MIT",
       "dependencies": {
         "async": "3.2.6",
@@ -176,7 +176,7 @@
         "commander": "11.1.0",
         "glob": "^9.0.0",
         "is-glob": "^4.0.3",
-        "node-sarif-builder": "^3.3.1",
+        "node-sarif-builder": "^3.4.0",
         "strip-json-comments": "3.1.1",
         "xml": "1.0.1"
       },
@@ -253,9 +253,9 @@
       }
     },
     "node_modules/node-sarif-builder": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.3.1.tgz",
-      "integrity": "sha512-8z5dAbhpxmk/WRQHXlv4V0h+9Y4Ugk+w08lyhV/7E/CQX9yDdBc3025/EG+RSMJU2aPFh/IQ7XDV7Ti5TLt/TA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.4.0.tgz",
+      "integrity": "sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==",
       "license": "MIT",
       "dependencies": {
         "@types/sarif": "^2.1.7",

--- a/htmlhint-server/package.json
+++ b/htmlhint-server/package.json
@@ -8,7 +8,7 @@
     "watch": "tsc --watch -p ./src"
   },
   "dependencies": {
-    "htmlhint": "^1.8.0",
+    "htmlhint": "^1.8.1",
     "strip-json-comments": "3.1.1",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.12",

--- a/htmlhint/CHANGELOG.md
+++ b/htmlhint/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 All notable changes to the "vscode-htmlhint" extension will be documented in this file.
 
-### v1.15.0 (TBD)
+### v1.16.0 (2026-02-06)
+
+- Update HTMLHint to v1.8.1
+
+### v1.15.1 (2025-11-28)
+
+- Fix build issue with v1.15.0
+- Internal improvements and optimizations
+
+### v1.15.0 (2025-11-28)
 
 - Add autofix for the `empty-tag-not-self-closed` rule
 - Add autofix for the `link-rel-canonical-require` rule

--- a/htmlhint/package-lock.json
+++ b/htmlhint/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-htmlhint",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-htmlhint",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "bundleDependencies": [
         "vscode-languageclient",
         "htmlhint",
@@ -18,7 +18,7 @@
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "htmlhint": "1.8.0",
+        "htmlhint": "1.8.1",
         "strip-json-comments": "3.1.1",
         "vscode-languageclient": "9.0.1",
         "vscode-languageserver": "9.0.1",
@@ -248,9 +248,9 @@
       "license": "MIT"
     },
     "node_modules/fs-extra": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
-      "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
+      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -335,9 +335,9 @@
       }
     },
     "node_modules/htmlhint": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/htmlhint/-/htmlhint-1.8.0.tgz",
-      "integrity": "sha512-RT1UsSM3ldlVQ7DDqWnbbRY1Rf6wwudmdYwiJzIyZVapA0jcka5r2lE2RkMLzTDN5c8Vc06yis57TaTpZ6o3Dg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/htmlhint/-/htmlhint-1.8.1.tgz",
+      "integrity": "sha512-xNaihALJIBnvPIBQRGlA/T84Ew7RMKduvKqgQeS4pqZ8zLg09CBDc8LYiWQtgvsllE32+fhgBUYesIcuyeDodw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -346,7 +346,7 @@
         "commander": "11.1.0",
         "glob": "^9.0.0",
         "is-glob": "^4.0.3",
-        "node-sarif-builder": "^3.3.1",
+        "node-sarif-builder": "^3.4.0",
         "strip-json-comments": "3.1.1",
         "xml": "1.0.1"
       },
@@ -589,9 +589,9 @@
       "license": "MIT"
     },
     "node_modules/node-sarif-builder": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.3.1.tgz",
-      "integrity": "sha512-8z5dAbhpxmk/WRQHXlv4V0h+9Y4Ugk+w08lyhV/7E/CQX9yDdBc3025/EG+RSMJU2aPFh/IQ7XDV7Ti5TLt/TA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.4.0.tgz",
+      "integrity": "sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {

--- a/htmlhint/package.json
+++ b/htmlhint/package.json
@@ -3,7 +3,7 @@
   "displayName": "HTMLHint",
   "description": "VS Code integration for HTMLHint - A Static Code Analysis Tool for HTML",
   "icon": "images/icon.png",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "publisher": "HTMLHint",
   "galleryBanner": {
     "color": "#333333",
@@ -87,7 +87,7 @@
     "vscode:prepublish": "npm run compile && npm run bundle-dependencies",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "bundle-dependencies": "npm install --no-package-lock --no-save --no-fund htmlhint@1.8.0 strip-json-comments@3.1.1 vscode-languageserver@9.0.1 vscode-languageserver-textdocument@1.0.12 vscode-uri@3.1.0 ignore@7.0.5",
+    "bundle-dependencies": "npm install --no-package-lock --no-save --no-fund htmlhint@1.8.1 strip-json-comments@3.1.1 vscode-languageserver@9.0.1 vscode-languageserver-textdocument@1.0.12 vscode-uri@3.1.0 ignore@7.0.5",
     "package": "vsce package"
   },
   "devDependencies": {
@@ -97,7 +97,7 @@
     "typescript": "5.6.3"
   },
   "dependencies": {
-    "htmlhint": "1.8.0",
+    "htmlhint": "1.8.1",
     "strip-json-comments": "3.1.1",
     "vscode-languageclient": "9.0.1",
     "vscode-languageserver": "9.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "glob": "^13.0.0",
         "globals": "^16.5.0",
         "mocha": "^11.7.5",
-        "prettier": "3.7.4",
+        "prettier": "3.8.1",
         "ts-node": "^10.9.2",
         "typescript": "5.6.3"
       },
@@ -493,7 +493,6 @@
       "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -541,7 +540,6 @@
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -763,7 +761,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1161,7 +1158,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2346,7 +2342,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2364,9 +2359,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
-      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2788,7 +2783,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "glob": "^13.0.0",
     "globals": "^16.5.0",
     "mocha": "^11.7.5",
-    "prettier": "3.7.4",
+    "prettier": "3.8.1",
     "ts-node": "^10.9.2",
     "typescript": "5.6.3"
   },


### PR DESCRIPTION
This pull request updates the `vscode-htmlhint` extension and its server to use the latest version of HTMLHint and related dependencies. The main focus is on bumping the HTMLHint package to v1.8.1, along with updating other dependencies and reflecting these changes in the changelog and version numbers.

Dependency updates:

* Upgraded `htmlhint` dependency to version 1.8.1 in `htmlhint/package.json`, `htmlhint-server/package.json`, and their respective lock files. [[1]](diffhunk://#diff-08c2e20c51c924a1a15c0665ca960ca23af45ddd76dbfcd4a52f86d17ce8f066L100-R100) [[2]](diffhunk://#diff-4a6aebbd1a0c96ca571d4355aaa35d3ea2bb6ab00a1339ffb03bffaf6b55e28dL11-R11) [[3]](diffhunk://#diff-a19104f66b89f91fe059f01749d74668bde853816ad7a3407335eb08433ac08cL21-R21) [[4]](diffhunk://#diff-7326a869b37abfc401335ddaadaf40c59e1408ff1b74821f422330df1d25d783L11-R11) [[5]](diffhunk://#diff-a19104f66b89f91fe059f01749d74668bde853816ad7a3407335eb08433ac08cL338-R340) [[6]](diffhunk://#diff-7326a869b37abfc401335ddaadaf40c59e1408ff1b74821f422330df1d25d783L169-R179)
* Updated `node-sarif-builder` to version 3.4.0 and `fs-extra` to version 11.3.3 in all relevant lock files. [[1]](diffhunk://#diff-a19104f66b89f91fe059f01749d74668bde853816ad7a3407335eb08433ac08cL349-R349) [[2]](diffhunk://#diff-7326a869b37abfc401335ddaadaf40c59e1408ff1b74821f422330df1d25d783L256-R258) [[3]](diffhunk://#diff-a19104f66b89f91fe059f01749d74668bde853816ad7a3407335eb08433ac08cL592-R594) [[4]](diffhunk://#diff-a19104f66b89f91fe059f01749d74668bde853816ad7a3407335eb08433ac08cL251-R253) [[5]](diffhunk://#diff-7326a869b37abfc401335ddaadaf40c59e1408ff1b74821f422330df1d25d783L117-R119)

Versioning and changelog:

* Bumped extension version to 1.16.0 in `htmlhint/package.json` and `htmlhint/package-lock.json`. [[1]](diffhunk://#diff-08c2e20c51c924a1a15c0665ca960ca23af45ddd76dbfcd4a52f86d17ce8f066L6-R6) [[2]](diffhunk://#diff-a19104f66b89f91fe059f01749d74668bde853816ad7a3407335eb08433ac08cL3-R9)
* Updated the changelog in `htmlhint/CHANGELOG.md` to document the new version and dependency updates.

Build and tooling:

* Updated the `bundle-dependencies` script in `htmlhint/package.json` to install the new `htmlhint` version.
* Upgraded `prettier` dev dependency to 3.8.1 in the root `package.json`.