### PR TITLE
Use .nvmrc for Node and bump htmlhint

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 22
+          node-version-file: .nvmrc
 
       - run: npm ci
 

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -26,6 +26,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: .nvmrc
+
+      - run: npm ci
+
       - name: Lint Code Base
         uses: super-linter/super-linter/slim@61abc07d755095a68f4987d1c2c3d1d64408f1f9 # v8.5.0
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,22 +8,13 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  FORCE_COLOR: 2
-
 permissions:
   contents: read
 
 jobs:
   run:
-    name: Node ${{ matrix.node }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [22]
-        os: [ubuntu-latest]
+    name: Node
+    runs-on: ubuntu-latest
 
     steps:
       - name: Clone repository
@@ -34,7 +25,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: ${{ matrix.node }}
+          node-version-file: .nvmrc
           cache: npm
 
       - name: Install npm dependencies

--- a/htmlhint/package.json
+++ b/htmlhint/package.json
@@ -87,7 +87,7 @@
     "vscode:prepublish": "npm run compile && npm run bundle-dependencies",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "bundle-dependencies": "npm install --no-package-lock --no-save --no-fund htmlhint@1.8.1 strip-json-comments@3.1.1 vscode-languageserver@9.0.1 vscode-languageserver-textdocument@1.0.12 vscode-uri@3.1.0 ignore@7.0.5",
+    "bundle-dependencies": "npm install --no-package-lock --no-save --no-fund htmlhint@1.9.2 strip-json-comments@3.1.1 vscode-languageserver@9.0.1 vscode-languageserver-textdocument@1.0.12 vscode-uri@3.1.0 ignore@7.0.5",
     "package": "vsce package"
   },
   "devDependencies": {


### PR DESCRIPTION
Switch CI jobs to read the Node version from .nvmrc (publish, test, super-linter) instead of hardcoding a version or matrix variable, simplify the test workflow (remove matrix and FORCE_COLOR), and add a Node setup + npm ci step to the super-linter job so dependencies are installed before linting. Also update htmlhint in htmlhint/package.json from 1.8.1 to 1.9.2 in the bundle-dependencies script.