### PR TITLE
TypeScript 5.8 update

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -55,5 +55,6 @@ jobs:
           VALIDATE_JSON_PRETTIER: false
           VALIDATE_MARKDOWN_PRETTIER: false
           VALIDATE_NATURAL_LANGUAGE: false
+          VALIDATE_TRIVY: false
           VALIDATE_TYPESCRIPT_ES: false
           VALIDATE_TYPESCRIPT_PRETTIER: false

--- a/htmlhint-server/package-lock.json
+++ b/htmlhint-server/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@types/node": "22.19.17",
-        "typescript": "5.5.4"
+        "typescript": "5.8.3"
       },
       "engines": {
         "node": "*"
@@ -306,9 +306,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/htmlhint-server/package.json
+++ b/htmlhint-server/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@types/node": "22.19.17",
-    "typescript": "5.5.4"
+    "typescript": "5.8.3"
   },
   "engines": {
     "node": "*"

--- a/htmlhint/package-lock.json
+++ b/htmlhint/package-lock.json
@@ -29,7 +29,7 @@
         "@types/node": "^22.19.17",
         "@types/vscode": "^1.101.0",
         "@vscode/test-electron": "^2.5.2",
-        "typescript": "5.6.3"
+        "typescript": "5.8.3"
       },
       "engines": {
         "vscode": "^1.101.0"
@@ -860,9 +860,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/htmlhint/package-lock.json
+++ b/htmlhint/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-htmlhint",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-htmlhint",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "bundleDependencies": [
         "vscode-languageclient",
         "htmlhint",

--- a/htmlhint/package.json
+++ b/htmlhint/package.json
@@ -3,7 +3,7 @@
   "displayName": "HTMLHint",
   "description": "VS Code integration for HTMLHint - A Static Code Analysis Tool for HTML",
   "icon": "images/icon.png",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "publisher": "HTMLHint",
   "galleryBanner": {
     "color": "#333333",
@@ -94,7 +94,7 @@
     "@types/node": "^22.19.17",
     "@types/vscode": "^1.101.0",
     "@vscode/test-electron": "^2.5.2",
-    "typescript": "5.6.3"
+    "typescript": "5.8.3"
   },
   "dependencies": {
     "htmlhint": "1.9.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "mocha": "^11.7.5",
         "prettier": "3.8.1",
         "ts-node": "^10.9.2",
-        "typescript": "5.6.3"
+        "typescript": "5.8.3"
       },
       "engines": {
         "node": ">= 22.22.2"
@@ -2772,9 +2772,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
     "mocha": "^11.7.5",
     "prettier": "3.8.1",
     "ts-node": "^10.9.2",
-    "typescript": "5.6.3"
+    "typescript": "5.8.3"
   },
   "engines": {
-    "node": ">= 22.22.2"
+    "node": ">= 22.22"
   },
   "volta": {
     "node": "22.22.2"


### PR DESCRIPTION
This pull request primarily upgrades the TypeScript dependency across the project to version 5.8.3, ensuring consistency and up-to-date tooling in all relevant packages. It also bumps the `htmlhint` extension version and makes a minor adjustment to the node engine requirement. Additionally, a linter configuration is updated to disable Trivy validation.

Dependency upgrades:

* Upgraded `typescript` to version 5.8.3 in `htmlhint/package.json`, `htmlhint/package-lock.json`, `htmlhint-server/package.json`, `htmlhint-server/package-lock.json`, and the root `package.json`, and updated all related lockfile entries to match. [[1]](diffhunk://#diff-08c2e20c51c924a1a15c0665ca960ca23af45ddd76dbfcd4a52f86d17ce8f066L97-R97) [[2]](diffhunk://#diff-a19104f66b89f91fe059f01749d74668bde853816ad7a3407335eb08433ac08cL32-R32) [[3]](diffhunk://#diff-a19104f66b89f91fe059f01749d74668bde853816ad7a3407335eb08433ac08cL863-R865) [[4]](diffhunk://#diff-7326a869b37abfc401335ddaadaf40c59e1408ff1b74821f422330df1d25d783L19-R19) [[5]](diffhunk://#diff-7326a869b37abfc401335ddaadaf40c59e1408ff1b74821f422330df1d25d783L309-R311) [[6]](diffhunk://#diff-4a6aebbd1a0c96ca571d4355aaa35d3ea2bb6ab00a1339ffb03bffaf6b55e28dL19-R19) [[7]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L49-R52)

Version and engine updates:

* Bumped the `htmlhint` extension version from `1.16.0` to `1.17.0` in `htmlhint/package.json`.
* Relaxed the minimum required node version from `22.22.2` to `22.22` in the root `package.json`.

CI/linter configuration:

* Disabled Trivy validation in the super-linter GitHub Actions workflow by setting `VALIDATE_TRIVY: false` in `.github/workflows/super-linter.yml`.